### PR TITLE
chore: remove carthage and beta from workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,15 +32,15 @@ jobs:
         steps:
         - name: Checkout repository
           uses: actions/checkout@v2
-    
+
         - name: Install CocoaPods
           run: |
               sudo gem install cocoapods
-    
+
         - name: Run pod install
           run: |
               pod install --project-directory=snippets/MapsBetaSnippets
-    
+
         - name: Build project
           run: |
             echo "Building"
@@ -48,42 +48,21 @@ jobs:
             -scheme MapsBetaSnippets \
             -destination platform\=iOS\ Simulator,OS\=13.3,name\=iPhone\ 8 build | xcpretty
 
-    build-snippets-carthage:
-        runs-on: macos-latest
-
-        steps:
-        - name: Checkout repository
-          uses: actions/checkout@v2
-    
-        - name: Install Carthage
-          run: |
-              brew install carthage
-    
-        - name: Run carthage update
-          run: |
-              cd snippets
-              carthage update --platform iOS
-
-        - name: Run carthage update (XCFramework)
-          run: |
-              cd snippets/MapsBetaSnippets
-              carthage update --platform iOS
-
     build-MapsSnippets:
         runs-on: macos-latest
 
         steps:
         - name: Checkout repository
           uses: actions/checkout@v2
-    
+
         - name: Install CocoaPods
           run: |
               sudo gem install cocoapods
-    
+
         - name: Run pod install
           run: |
               pod install --project-directory=snippets/MapsSnippets
-    
+
         - name: Build project
           run: |
             echo "Building"
@@ -97,15 +76,15 @@ jobs:
         steps:
         - name: Checkout repository
           uses: actions/checkout@v2
-    
+
         - name: Install CocoaPods
           run: |
               sudo gem install cocoapods
-    
+
         - name: Run pod install
           run: |
               pod install --project-directory=snippets/MapsUtilsSnippets
-    
+
         - name: Build project
           run: |
             echo "Building"
@@ -119,15 +98,15 @@ jobs:
         steps:
         - name: Checkout repository
           uses: actions/checkout@v2
-    
+
         - name: Install CocoaPods
           run: |
               sudo gem install cocoapods
-    
+
         - name: Run pod install
           run: |
               pod install --project-directory=snippets/PlacesSnippets
-    
+
         - name: Build project
           run: |
             echo "Building"
@@ -141,20 +120,20 @@ jobs:
         steps:
         - name: Checkout repository
           uses: actions/checkout@v2
-    
+
         - name: Install CocoaPods
           run: |
               sudo gem install cocoapods
-    
+
         - name: Run pod install
           run: |
               pod install --project-directory=GoogleMapsBeta/
-    
+
         - name: Build project
           run: |
             echo "Replacing #error for API key"
             sed -i .prev '/#error/'d GoogleMaps/GoogleMapsDemos/SDKDemoAPIKey.h
-    
+
             echo "Building"
             xcodebuild -workspace GoogleMapsBeta/GoogleMapsBeta.xcworkspace \
             -scheme GoogleMapsBeta \
@@ -166,20 +145,20 @@ jobs:
         steps:
         - name: Checkout repository
           uses: actions/checkout@v2
-    
+
         - name: Install CocoaPods
           run: |
               sudo gem install cocoapods
-    
+
         - name: Run pod install
           run: |
               pod install --project-directory=GoogleMapsBeta-Swift/
-    
+
         - name: Build project
           run: |
             echo "Replacing #error for API key"
             sed -i .prev '/#error/'d GoogleMaps-Swift/GoogleMapsSwiftDemos/Swift/SDKConstants.swift
-    
+
             echo "Building"
             xcodebuild -workspace GoogleMapsBeta-Swift/GoogleMapsBeta-Swift.xcworkspace \
             -scheme GoogleMapsBeta-Swift \
@@ -191,20 +170,20 @@ jobs:
         steps:
         - name: Checkout repository
           uses: actions/checkout@v2
-    
+
         - name: Install CocoaPods
           run: |
               sudo gem install cocoapods
-    
+
         - name: Run pod install
           run: |
               pod install --project-directory=GoogleMaps/
-    
+
         - name: Build project
           run: |
             echo "Replacing #error for API key"
             sed -i .prev '/#error/'d GoogleMaps/GoogleMapsDemos/SDKDemoAPIKey.h
-    
+
             echo "Building"
             xcodebuild -workspace GoogleMaps/GoogleMapsDemos.xcworkspace \
             -scheme GoogleMapsDemos \
@@ -216,20 +195,20 @@ jobs:
         steps:
         - name: Checkout repository
           uses: actions/checkout@v2
-    
+
         - name: Install CocoaPods
           run: |
               sudo gem install cocoapods
-    
+
         - name: Run pod install
           run: |
               pod install --project-directory=GoogleMaps-Swift/
-    
+
         - name: Build project
           run: |
             echo "Replacing #error for API key"
             sed -i .prev '/#error/'d GoogleMaps-Swift/GoogleMapsSwiftDemos/Swift/SDKConstants.swift
-    
+
             echo "Building"
             xcodebuild -workspace GoogleMaps-Swift/GoogleMapsSwiftDemos.xcworkspace \
             -scheme GoogleMapsSwiftDemos \
@@ -241,20 +220,20 @@ jobs:
         steps:
         - name: Checkout repository
           uses: actions/checkout@v2
-    
+
         - name: Install CocoaPods
           run: |
               sudo gem install cocoapods
-    
+
         - name: Run pod install
           run: |
               pod install --project-directory=GooglePlaces/
-    
+
         - name: Build project
           run: |
             echo "Replacing #error for API key"
             sed -i .prev '/#error/'d GooglePlaces/GooglePlacesDemos/SDKDemoAPIKey.h
-    
+
             echo "Building"
             xcodebuild -workspace GooglePlaces/GooglePlacesDemos.xcworkspace \
             -scheme GooglePlacesDemos \
@@ -266,20 +245,20 @@ jobs:
         steps:
         - name: Checkout repository
           uses: actions/checkout@v2
-    
+
         - name: Install CocoaPods
           run: |
               sudo gem install cocoapods
-    
+
         - name: Run pod install
           run: |
               pod install --project-directory=GooglePlaces-Swift/
-    
+
         - name: Build project
           run: |
             echo "Replacing #error for API key"
             sed -i .prev '/#error/'d GooglePlaces-Swift/GooglePlacesSwiftDemos/Swift/SDKDemoAPIKey.swift
-    
+
             echo "Building"
             xcodebuild -workspace GooglePlaces-Swift/GooglePlacesSwiftDemos.xcworkspace \
             -scheme GooglePlacesSwiftDemos \
@@ -291,15 +270,15 @@ jobs:
         steps:
         - name: Checkout repository
           uses: actions/checkout@v2
-    
+
         - name: Install CocoaPods
           run: |
               sudo gem install cocoapods
-    
+
         - name: Run pod install
           run: |
               pod install --project-directory=tutorials/current-place-on-map/
-    
+
         - name: Build project
           run: |
             echo "Building"
@@ -313,15 +292,15 @@ jobs:
         steps:
         - name: Checkout repository
           uses: actions/checkout@v2
-    
+
         - name: Install CocoaPods
           run: |
               sudo gem install cocoapods
-    
+
         - name: Run pod install
           run: |
               pod install --project-directory=tutorials/map-with-marker/
-    
+
         - name: Build project
           run: |
             echo "Building"
@@ -335,15 +314,15 @@ jobs:
         steps:
         - name: Checkout repository
           uses: actions/checkout@v2
-    
+
         - name: Install CocoaPods
           run: |
               sudo gem install cocoapods
-    
+
         - name: Run pod install
           run: |
               pod install --project-directory=tutorials/places-address-form/
-    
+
         - name: Build project
           run: |
             echo "Building"
@@ -379,13 +358,9 @@ jobs:
     test: # used as required status check
       runs-on: ubuntu-latest
       needs:
-        - build-MapsBetaSnippets
-        - build-snippets-carthage
         - build-MapsSnippets
         - build-MapsUtilsSnippets
         - build-PlacesSnippets
-        - build-GoogleMapsBeta
-        - build-GoogleMapsBeta-Swift
         - build-GoogleMaps
         - build-GoogleMaps-Swift
         - build-GooglePlaces
@@ -394,5 +369,5 @@ jobs:
         - build-map-with-marker
         - build-places-address-form
         - build-MapsPlacesDemo-form
-      steps: 
+      steps:
         - run: echo "Fail if all other steps are not successful"

--- a/.github/workflows/pod_try_sync.yml
+++ b/.github/workflows/pod_try_sync.yml
@@ -86,5 +86,5 @@ jobs:
         title: 'chore: Update Maps and Places samples from CocoaPods'
         body: |
           Pulling in changes from `pod try GoogleMaps` and `pod try GooglePlaces`.
-          **Note:** Make sure to update CocoaPods (Podfile) and Carthage (Cartfile) dependencies
+          **Note:** Make sure to update CocoaPods (Podfile) dependencies
         branch: googlemaps-bot/update_samples


### PR DESCRIPTION
Carthage support was [frozen at v6.2.1](https://developers.google.com/maps/documentation/ios-sdk/carthage)
Beta was [decommissioned in late 2022](https://developers.google.com/maps/documentation/ios-sdk/release-notes#2021-08-18).
