### PR TITLE
chore: Updated README to remove sales contact requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ $ pod install
 $ open GoogleNavigationSwiftDemos.xcworkspace
 ```
 
-You will need to add an API Key to `GoogleNavigationDemos/SDKDemoAPIKey.h`. Please
-[contact the sales team](https://cloud.google.com/contact-maps)
+You will need to add an API Key to `GoogleNavigationDemos/SDKDemoAPIKey.h`. Please see the
+[documentation](https://developers.google.com/maps/documentation/navigation/ios-sdk/get-api-key)
 for details on how to get an API Key.
 
 ## MapsAndPlacesDemo


### PR DESCRIPTION
Updated README to remove sales contact requirement for the Nav SDK and link to developer docs instead.
