### PR TITLE
Remove references to setMetalRendererEnabled

### DIFF
--- a/GoogleMaps-Swift/GoogleMapsSwiftXCFrameworkDemos/Swift/AppDelegate.swift
+++ b/GoogleMaps-Swift/GoogleMapsSwiftXCFrameworkDemos/Swift/AppDelegate.swift
@@ -25,8 +25,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIWindowSceneDelegate {
   ) -> Bool {
 
     GMSServices.provideAPIKey(SDKConstants.apiKey)
-    // Metal is the preferred renderer.
-    GMSServices.setMetalRendererEnabled(true)
     services = GMSServices.sharedServices()
 
     return true

--- a/GoogleMaps/GoogleMapsDemos/DemoAppDelegate.m
+++ b/GoogleMaps/GoogleMapsDemos/DemoAppDelegate.m
@@ -36,8 +36,6 @@
   }
   [GMSServices provideAPIKey:kAPIKey];
 
-  // Metal is the preferred renderer.
-  [GMSServices setMetalRendererEnabled:YES];
   self.servicesHandle = [GMSServices sharedServices];
 
   // Log the required open source licenses! Yes, just NSLog-ing them is not enough but is good for a

--- a/GoogleMaps/GoogleMapsXCFrameworkDemos/DemoAppDelegate.m
+++ b/GoogleMaps/GoogleMapsXCFrameworkDemos/DemoAppDelegate.m
@@ -39,8 +39,6 @@
   }
   [GMSServices provideAPIKey:kAPIKey];
 
-  // Metal is the preferred renderer.
-  [GMSServices setMetalRendererEnabled:YES];
   self.servicesHandle = [GMSServices sharedServices];
 
   // Log the required open source licenses! Yes, just NSLog-ing them is not enough but is good for a


### PR DESCRIPTION
Remove references to `setMetalRendererEnabled` since metal is already enabled by default and the `setMetalRendererEnabled` API has been deprecated.